### PR TITLE
Add SNLDS as baseline for basketball experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ data/basketball/baller2vec_format/processed/
 #unit test outputs
 tests/outputs/
 
+# this magically appeared somehow. not sure why. perhaps when
+# installing linderman's repo.
+src/ssm/
+

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,10 @@
 # Environment setup instructions
 
-## 1) Install micromamba
+We provide two options for environment setup, depending on which Python package manager you prefer to use: `micromamba` or `pyenv`. 
+
+## Using micromamba
+
+### 1) Install micromamba
 
 Follow these directions
 
@@ -24,7 +28,7 @@ Otherwise, on your laptop, be sure your path is updated
 export PATH="/path/to/bin/micromamba:$PATH"
 ```
 
-## 2) Install a dedicated env for this project 
+### 2) Install a dedicated env for this project 
 
 Uses file [`dynagroup_env.yml`](https://github.com/tufts-ml/team-dynamics-time-series/blob/mch_install/dynagroup_env.yml)
 
@@ -37,7 +41,7 @@ $ micromamba create -f dynagroup_env.yml
 
 Will take about 5-10 min (on a laptop), somehow much longer on cluster
 
-## 3) Activate and run a test
+### 3) Activate and run a demo
 
 ```
 $ micromamba activate dynagroup_env_310
@@ -46,3 +50,32 @@ $ python demo_cavi_on_figure8.py
 ``` 
 
 Should produce a lot of text to stdout and save lots of figures to files.
+
+
+## Using pyenv
+
+### 1) Create a dedicated env for this project
+```
+pyenv virtualenv 3.10.16 team
+pyenv activate team
+```
+
+### 2) Install this project and dependencies
+```
+# install standard dependencies
+pip install -r requirements.txt 
+pip install -r dev-requirements.txt
+
+# install Linderman's ssm dependency
+pip install --no-build-isolation git+https://github.com/lindermanlab/ssm@6c856ad3967941d176eb348bcd490cfaaa08ba60 # no build isolation is because seem lacks pyproject.toml
+
+# install this project 
+pip install .
+```
+
+### 3) Run a demo
+
+```
+cd src/dynagroup/model2a/figure8/demos/
+python demo_cavi_on_figure8.py 
+``` 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,3 +79,7 @@ pip install .
 cd src/dynagroup/model2a/figure8/demos/
 python demo_cavi_on_figure8.py 
 ``` 
+
+### Appendix: On the `ssm` dependency
+
+We must use additional care when installing the `ssm` dependency. In particular, we install it with the `--no-build-isolation` flag.   Why? As of PEP 517, setuptools runs setup.py in a clean build environment (which doesn’t include the existing virtual environment or its packages).  But building `ssm` requires a pre-existing package (`numpy`). Current best practice (as of PEP 518) is for a package in this situation to  include a `pyproject.toml` file, using `[build-system] requires` to declare that build dependencies (`numpy` in this case) must be available at build time.   However, `ssm` does not have a `pyproject.toml` file. We circumvent this deficiency of `ssm` by using the `--no-build-isolation` flag to allow `numpy` to exist in the build environment (since we would have already installed it in `requirements.txt`).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ B. To train baseline forecasts, use:
 1. [_FigureEight_: DSARF Ind., Pool., Concat.](https://github.com/tufts-ml/dsarf_agentformer_baseline_for_hsrdm/tree/kgili/dsarf_on_figure_8/DSARF_on_figure_8.ipynb)
 2. [Basketball: AgentFormer](https://github.com/tufts-ml/dsarf_agentformer_baseline_for_hsrdm/tree/main/agentformer_on_bball) 
 3. [Basketball: GroupNet](https://github.com/mikewojnowicz/GroupNet/tree/aistats)
-4. [MarchingBand: DSARF](https://github.com/tufts-ml/dsarf_agentformer_baseline_for_hsrdm/tree/kgili/dsarf_on_marching/DSARF_on_marchingband.ipynb) 
+4. [Basketball: SNLDS](https://github.com/mikewojnowicz/REDSDS) 
+5. [MarchingBand: DSARF](https://github.com/tufts-ml/dsarf_agentformer_baseline_for_hsrdm/tree/kgili/dsarf_on_marching/DSARF_on_marchingband.ipynb) 
 
 
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,6 +5,7 @@ pylint
 coverage
 flake8
 ipython
+pyqt5 # seems to be needed for ipython
 isort; python_version >= '3.8'
 pytest
 pytest-cov

--- a/dynagroup_env.yml
+++ b/dynagroup_env.yml
@@ -21,6 +21,6 @@ dependencies:
     - jaxlib
     - jax-dataclasses
     - tensorflow-probability
-    - "git+https://github.com/lindermanlab/ssm@6c856ad3#egg=ssm"
+    - "git+https://github.com/lindermanlab/ssm@6c856ad3967941d176eb348bcd490cfaaa08ba60"
     - dynamax
     - pomegranate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,17 @@
+[project]
+name = "team-dynamics-time-series"
+version = "0.1.0"
+description = "Time series analysis of team dynamics"
+authors = [
+    { name="Your Name", email="your.email@example.com" }
+]
+dependencies = [
+    "numpy",
+    "pandas",
+    "matplotlib",
+]
+requires-python = ">=3.8"
+
 [build-system]
 requires = ["setuptools", "wheel"]
 
@@ -23,3 +37,8 @@ exclude = '''
   | _pb2\.py        # skip auto-generated protobuf code
 )
 '''
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.5",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,10 @@ cython # for Linderman's ssm package
 # for some reason doing an editable install to this package pip install -e .
 # requires that the below is installed manually.
 #
-# -e git+https://github.com/lindermanlab/ssm@6c856ad3967941d176eb348bcd490cfaaa08ba60#egg=ssm 
+# That is, do
+#
+# USE_OPENMP=True pip install git+https://github.com/lindermanlab/ssm@6c856ad3967941d176eb348bcd490cfaaa08ba60#egg=ssm
+
 
 pomegranate # just for Gaussian mixture models with sample weights (used to initialize vonMises AR-HMM)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 
 cython # for Linderman's ssm package 
+setuptools # for Linderman's ssm package 
 
 # `ssm` repo below is for forward backward algo (ssm.messages.hmm_expected_states)
 # we get an error if we try to install from pip; the github repo is newer.
@@ -9,7 +10,9 @@ cython # for Linderman's ssm package
 # That is, do
 #
 # USE_OPENMP=True pip install git+https://github.com/lindermanlab/ssm@6c856ad3967941d176eb348bcd490cfaaa08ba60#egg=ssm
-
+# or 
+#pip install --no-build-isolation git+https://github.com/lindermanlab/ssm@6c856ad3967941d176eb348bcd490cfaaa08ba60 
+# where `no build isolation` may be requured because ssm lacks pyproject.toml
 
 pomegranate # just for Gaussian mixture models with sample weights (used to initialize vonMises AR-HMM)
 
@@ -30,3 +33,7 @@ jax_dataclasses
 
 tensorflow_probability
 dynamax
+# or try pip install git+https://github.com/probml/dynamax.git@51b7dc5
+
+
+scikit-image # for marching band experiment 

--- a/src/dynagroup/hmm_posterior.py
+++ b/src/dynagroup/hmm_posterior.py
@@ -478,7 +478,7 @@ def make_hmm_posterior_summaries_from_list(
         expected_joints_list,
         log_normalizers_list,
         entropies_list,
-    ) = ([None] * J, [None] * J, [None] * J, [None] * J)
+    ) = ([jnp.nan] * J, [jnp.nan] * J, [jnp.nan] * J, [jnp.nan] * J)
     for j in range(J):
         expected_regimes_list[j] = list_of_hmm_posterior_summaries[j].expected_regimes
         expected_joints_list[j] = list_of_hmm_posterior_summaries[j].expected_joints

--- a/src/dynagroup/model2a/basketball/court.py
+++ b/src/dynagroup/model2a/basketball/court.py
@@ -29,8 +29,7 @@ Y_MAX_COURT = 50
 # TODO: Can I make a scheme where I plot the court in the NORMALIZED coords,
 # so that I don't have to unnormalize all the time?!
 COURT_AXIS_UNNORM = [X_MIN_COURT, X_MAX_COURT, Y_MIN_COURT, Y_MAX_COURT]
-image_path = os.path.abspath("image/nba_court_T.png")
-COURT_IMAGE = mpimg.imread(image_path)
+COURT_IMAGE = mpimg.imread("image/nba_court_T.png")
 
 ###
 # Normalize/Unnormalize

--- a/src/dynagroup/model2a/basketball/demos/baller2vec_format/CLE_starters/demo_full_pipeline.py
+++ b/src/dynagroup/model2a/basketball/demos/baller2vec_format/CLE_starters/demo_full_pipeline.py
@@ -171,6 +171,7 @@ results_init = smart_initialize_model_2a(
 )
 params_init = results_init.params
 most_likely_entity_states_after_init = results_init.record_of_most_likely_entity_states[:, :, -1]  # TxJ
+VES_init, VEZ_init = results_init.ES_summary, results_init.EZ_summaries
 
 elbo_init = compute_elbo_from_initialization_results(
     results_init,
@@ -218,22 +219,22 @@ if animate_initialization:
 # Inference
 ####
 
-VES_summary, VEZ_summaries, params_learned, elbo_decomposed, classification_accuracy = run_CAVI_with_JAX(
-    jnp.asarray(DATA_TRAIN.player_coords),
-    n_cavi_iterations,
-    results_init,   
+VES_summary, VEZ_summaries, params_learned, elbo_list, classification_list = run_CAVI_with_JAX(
+    params_init,
+    VES_init, VEZ_init, system_transition_prior,
     model_basketball,
+    jnp.asarray(DATA_TRAIN.player_coords),
     DATA_TRAIN.example_stop_idxs,
+    n_cavi_iterations,
     M_step_toggles_from_strings(
         M_step_toggle_for_STP,
         M_step_toggle_for_ETP,
         M_step_toggle_for_continuous_state_parameters,
         M_step_toggle_for_IP,
     ),
-    num_M_step_iters,
-    system_transition_prior,
-    system_covariates,
-    use_continuous_states,
+    num_M_step_iters = num_M_step_iters,
+    system_covariates= system_covariates,
+    use_continuous_states=use_continuous_states,
 )
 
 if make_verbose_CAVI_plots:

--- a/src/dynagroup/model2a/basketball/demos/baller2vec_format/CLE_starters/demo_metrics_from_forecast_collection.py
+++ b/src/dynagroup/model2a/basketball/demos/baller2vec_format/CLE_starters/demo_metrics_from_forecast_collection.py
@@ -12,8 +12,7 @@ from dynagroup.model2a.basketball.forecast.main_analysis import (
 )
 
 
-#SAVE_DIR = "/Users/miw267/Repos/tmlr-2024/images/basketball"
-SAVE_DIR = "/Users/miw267/Desktop/tmp/"
+SAVE_DIR = "/Users/miw267/Repos/tmlr-2024/images/basketball"
 
 @dataclass
 class Result_For_Data_Size:

--- a/src/dynagroup/model2a/basketball/demos/baller2vec_format/CLE_starters/demo_metrics_from_forecast_collection.py
+++ b/src/dynagroup/model2a/basketball/demos/baller2vec_format/CLE_starters/demo_metrics_from_forecast_collection.py
@@ -6,13 +6,14 @@ import numpy as np
 from dynagroup.model2a.basketball.forecast.main_analysis import (
     compute_metrics,
     load_agentformer_forecasts,
+    load_SNLDS_forecasts,
     load_dynagroup_forecasts,
     load_groupnet_forecasts,
 )
 
 
-SAVE_DIR = "/Users/miw267/Repos/tmlr-2024/images/basketball"
-
+#SAVE_DIR = "/Users/miw267/Repos/tmlr-2024/images/basketball"
+SAVE_DIR = "/Users/miw267/Desktop/tmp/"
 
 @dataclass
 class Result_For_Data_Size:
@@ -24,9 +25,15 @@ class Result_For_Data_Size:
 
 ### Get forecasts (agentformer)
 forecasts_dict = {}
+
 forecasts_dict["agentformer_small"] = load_agentformer_forecasts("small")
 forecasts_dict["agentformer_medium"] = load_agentformer_forecasts("medium")
 forecasts_dict["agentformer_large"] = load_agentformer_forecasts("large")
+
+forecasts_dict["SNLDS_small"] = load_SNLDS_forecasts("small")
+forecasts_dict["SNLDS_medium"] = load_SNLDS_forecasts("medium")
+forecasts_dict["SNLDS_large"] = load_SNLDS_forecasts("large")
+
 
 forecasts_dict["groupnet_small"] = load_groupnet_forecasts("small", n_epochs=100, n_its_per_epoch=1000)
 forecasts_dict["groupnet_medium"] = load_groupnet_forecasts("medium", n_epochs=100, n_its_per_epoch=1000)
@@ -117,7 +124,7 @@ from statsmodels.stats.multitest import fdrcorrection
 
 
 focal_models_to_competitor_models = {
-    "ours": ["agentformer", "groupnet", "no_system_switches", "no_recurrence", "fixed_velocity"],
+    "ours": ["agentformer", "groupnet", "SNLDS", "no_system_switches", "no_recurrence", "fixed_velocity"],
 }
 
 uncorrected_p_vals_dict = OrderedDict()
@@ -219,7 +226,7 @@ from dynagroup.model2a.basketball.forecast.plots import (
 
 
 ### arguments
-models_list = ["ours_large", "no_system_switches_large", "no_recurrence_large", "agentformer_large", "groupnet_large"]
+models_list = ["ours_large", "no_system_switches_large", "no_recurrence_large", "agentformer_large", "groupnet_large", "SNLDS_large"]
 forecasts_list = [forecasts_dict[model] for model in models_list]
 metrics_list = [metrics_dict[model] for model in models_list]
 

--- a/src/dynagroup/model2a/basketball/demos/baller2vec_format/TOR_vs_CHA/demo_of_TOR_vs_CHA_with_masking.py
+++ b/src/dynagroup/model2a/basketball/demos/baller2vec_format/TOR_vs_CHA/demo_of_TOR_vs_CHA_with_masking.py
@@ -162,6 +162,7 @@ results_init = smart_initialize_model_2a(
 )
 params_init = results_init.params
 CSP_init = params_init.CSP  # JxKxDxD
+VES_init, VEZ_init = results_init.ES_summary, results_init.EZ_summaries
 
 
 ###
@@ -233,11 +234,13 @@ find_forward_sim_t0_for_entity_sample = lambda x: np.shape(xs)[0] - forecast_hor
 ####
 
 VES_summary, VEZ_summaries, params_learned, elbo_decomposed = run_CAVI_with_JAX(
-    jnp.asarray(xs),
-    n_cavi_iterations,
-    results_init,
+    params_init,
+    VES_init, VEZ_init,
+    system_transition_prior,
     model_basketball,
+    jnp.asarray(xs),
     event_stop_idxs,
+    n_cavi_iterations,
     M_step_toggles_from_strings(
         M_step_toggle_for_STP,
         M_step_toggle_for_ETP,
@@ -245,7 +248,6 @@ VES_summary, VEZ_summaries, params_learned, elbo_decomposed = run_CAVI_with_JAX(
         M_step_toggle_for_IP,
     ),
     num_M_step_iters,
-    system_transition_prior,
     system_covariates,
     use_continuous_states,
 )

--- a/src/dynagroup/model2a/basketball/demos/baller2vec_format/TOR_vs_CHA/demo_of_TOR_vs_CHA_with_test_set_split.py
+++ b/src/dynagroup/model2a/basketball/demos/baller2vec_format/TOR_vs_CHA/demo_of_TOR_vs_CHA_with_test_set_split.py
@@ -155,6 +155,7 @@ results_init = smart_initialize_model_2a(
     save_dir,
 )
 params_init = results_init.params
+VES_init, VEZ_init = results_init.ES_summary, results_init.EZ_summaries
 most_likely_entity_states_after_init = results_init.record_of_most_likely_entity_states[:, :, -1]  # TxJ
 CSP_init = params_init.CSP  # JxKxDxD
 
@@ -179,11 +180,13 @@ if animate_initialization:
 ####
 
 VES_summary, VEZ_summaries, params_learned, elbo_decomposed = run_CAVI_with_JAX(
-    jnp.asarray(xs_train),
-    n_cavi_iterations,
-    results_init,
+    params_init,
+    VES_init, VEZ_init,
+    system_transition_prior,
     model_basketball,
+    jnp.asarray(xs_train),
     example_end_times_train,
+    n_cavi_iterations,
     M_step_toggles_from_strings(
         M_step_toggle_for_STP,
         M_step_toggle_for_ETP,
@@ -191,7 +194,6 @@ VES_summary, VEZ_summaries, params_learned, elbo_decomposed = run_CAVI_with_JAX(
         M_step_toggle_for_IP,
     ),
     num_M_step_iters,
-    system_transition_prior,
     system_covariates,
     use_continuous_states,
 )

--- a/src/dynagroup/model2a/basketball/demos/orig_format/demo_basketball_multievent.py
+++ b/src/dynagroup/model2a/basketball/demos/orig_format/demo_basketball_multievent.py
@@ -120,6 +120,7 @@ results_init = smart_initialize_model_2a(
 )
 
 params_init = results_init.params
+VES_init, VEZ_init = results_init.ES_summary, results_init.EZ_summaries
 
 # initialization_results
 
@@ -181,11 +182,13 @@ if do_init_plots:
 # # ####
 
 VES_summary, VEZ_summaries, params_learned, elbo_decomposed = run_CAVI_with_JAX(
-    jnp.asarray(DATA.positions),
-    n_cavi_iterations,
-    results_init,
+    params_init,
+    VES_init, VEZ_init,
+    system_transition_prior,
     model_basketball,
+    jnp.asarray(DATA.positions),
     DATA.event_boundaries,
+    n_cavi_iterations,
     M_step_toggles_from_strings(
         M_step_toggle_for_STP,
         M_step_toggle_for_ETP,
@@ -193,7 +196,6 @@ VES_summary, VEZ_summaries, params_learned, elbo_decomposed = run_CAVI_with_JAX(
         M_step_toggle_for_IP,
     ),
     num_M_step_iters,
-    system_transition_prior,
     system_covariates=jnp.asarray(system_covariates),
 )
 

--- a/src/dynagroup/model2a/basketball/demos/orig_format/demo_basketball_one_play.py
+++ b/src/dynagroup/model2a/basketball/demos/orig_format/demo_basketball_one_play.py
@@ -123,6 +123,7 @@ results_init = smart_initialize_model_2a(
     save_dir=save_dir,
 )
 params_init = results_init.params
+VES_init, VEZ_init = results_init.ES_summary, results_init.EZ_summaries
 
 # initialization_results
 
@@ -149,11 +150,13 @@ print_multi_level_regime_occupancies_after_init(results_init)
 ####
 
 VES_summary, VEZ_summaries, params_learned, elbo_decomposed = run_CAVI_with_JAX(
-    jnp.asarray(xs),
-    n_cavi_iterations,
-    results_init,
+    params_init,
+    VES_init, VEZ_init,
+    system_transition_prior,
     model_basketball,
+    jnp.asarray(xs),
     example_end_times,
+    n_cavi_iterations,
     M_step_toggles_from_strings(
         M_step_toggle_for_STP,
         M_step_toggle_for_ETP,
@@ -161,6 +164,5 @@ VES_summary, VEZ_summaries, params_learned, elbo_decomposed = run_CAVI_with_JAX(
         M_step_toggle_for_IP,
     ),
     num_M_step_iters,
-    system_transition_prior,
     system_covariates,
 )

--- a/src/dynagroup/model2a/basketball/forecast/main_analysis.py
+++ b/src/dynagroup/model2a/basketball/forecast/main_analysis.py
@@ -78,6 +78,23 @@ def load_agentformer_forecasts(size: str) -> NumpyArray5D:
 
     return unnormalize_coords(forecasts_normalized)
 
+def load_SNLDS_forecasts(size: str) -> NumpyArray5D:
+    """
+    Argument:
+        size: in [small, medium, large]
+    Returns:
+        array of shape (E,S,T_forecast,J,D)
+    """
+
+    FILEPATH_SNLDS = (
+        f"results/basketball/CLE_starters/artifacts_external/SNLDS_sampled_trajectories_{size}_set.npy"
+    )
+
+    forecasts_normalized = np.load(FILEPATH_SNLDS)  # (E,S, T, J, D)
+
+    return unnormalize_coords(forecasts_normalized)
+
+
 
 def load_dynagroup_forecasts(dir_forecasts_ours: str) -> Tuple[NumpyArray5D, NumpyArray4D, NumpyArray4D]:
     """

--- a/src/dynagroup/model2a/basketball/forecast/main_analysis.py
+++ b/src/dynagroup/model2a/basketball/forecast/main_analysis.py
@@ -91,7 +91,6 @@ def load_SNLDS_forecasts(size: str) -> NumpyArray5D:
     )
 
     forecasts_normalized = np.load(FILEPATH_SNLDS)  # (E,S, T, J, D)
-
     return unnormalize_coords(forecasts_normalized)
 
 

--- a/src/dynagroup/model2a/figure8/demos/demo_fig8_complete_pooling.py
+++ b/src/dynagroup/model2a/figure8/demos/demo_fig8_complete_pooling.py
@@ -189,6 +189,7 @@ results_init = smart_initialize_model_2a(
     plots_dir,
 )
 params_init = results_init.params
+VES_init, VEZ_init = results_init.ES_summary, results_init.EZ_summaries
 
 
 ###
@@ -197,11 +198,13 @@ params_init = results_init.params
 
 
 VES_summary, VEZ_summaries, params_learned, elbo_decomposed, classification_list = run_CAVI_with_JAX(
-    jnp.asarray(xs_for_inference),
-    n_cavi_iterations,
-    results_init,
+    params_init,
+    VES_init, VEZ_init,
+    system_transition_prior,
     model,
+    jnp.asarray(xs_for_inference),
     example_end_times,
+    n_cavi_iterations,
     M_step_toggles_from_strings(
         M_step_toggle_for_STP,
         M_step_toggle_for_ETP,
@@ -209,7 +212,6 @@ VES_summary, VEZ_summaries, params_learned, elbo_decomposed, classification_list
         M_step_toggle_for_IP,
     ),
     num_M_step_iters,
-    system_transition_prior,
     system_covariates,
     use_continuous_states,
 )

--- a/src/dynagroup/model2a/figure8/demos/demo_fig8_concatenation.py
+++ b/src/dynagroup/model2a/figure8/demos/demo_fig8_concatenation.py
@@ -206,6 +206,7 @@ results_init = smart_initialize_model_2a(
     save_dir=plots_dir,
 )
 params_init = results_init.params
+VES_init, VEZ_init = results_init.ES_summary, results_init.EZ_summaries
 
 
 ###
@@ -214,11 +215,13 @@ params_init = results_init.params
 
 
 VES_summary, VEZ_summaries, params_learned, elbo_decomposed, classification_list = run_CAVI_with_JAX(
-    jnp.asarray(xs_for_inference),
-    n_cavi_iterations,
-    results_init,
+    params_init,
+    VES_init, VEZ_init,
+    system_transition_prior,
     model,
+    jnp.asarray(xs_for_inference),
     example_end_times,
+    n_cavi_iterations,
     M_step_toggles_from_strings(
         M_step_toggle_for_STP,
         M_step_toggle_for_ETP,

--- a/src/dynagroup/model2a/marching_band/demo.py
+++ b/src/dynagroup/model2a/marching_band/demo.py
@@ -167,6 +167,7 @@ results_init = smart_initialize_model_2a(
     save_dir=plots_dir,
 )
 params_init = results_init.params
+VES_init, VEZ_init = results_init.ES_summary, results_init.EZ_summaries
 
 
 elbo_init = compute_elbo_from_initialization_results(
@@ -185,11 +186,13 @@ print(f"ELBO after init: {elbo_init:.02f}")
 ####
 
 VES_summary, VEZ_summaries, params_learned, elbo_decomposed, classification_accuracy = run_CAVI_with_JAX(
-    jnp.asarray(DATA),
-    n_cavi_iterations,
-    results_init,
+    params_init,
+    VES_init, VEZ_init,
+    system_transition_prior,
     model,
+    jnp.asarray(DATA),
     example_end_times,
+    n_cavi_iterations,
     M_step_toggles_from_strings(
         M_step_toggle_for_STP,
         M_step_toggle_for_ETP,
@@ -197,7 +200,6 @@ VES_summary, VEZ_summaries, params_learned, elbo_decomposed, classification_accu
         M_step_toggle_for_IP,
     ),
     num_M_step_iters,
-    system_transition_prior,
     system_covariates,
     use_continuous_states,
     true_system_regimes,

--- a/src/dynagroup/model2a/supra/demos/demo_supra_squad_with_group_inference.py
+++ b/src/dynagroup/model2a/supra/demos/demo_supra_squad_with_group_inference.py
@@ -148,6 +148,7 @@ results_init = smart_initialize_model_2a_for_circles(
     parallelize_the_CSP_M_step_for_the_bottom_half_model=False,
 )
 params_init = results_init.params
+VES_init, VEZ_init = results_init.ES_summary, results_init.EZ_summaries
 
 
 ###
@@ -218,11 +219,13 @@ report_on_directional_attractors(params_init)
 
 # TODO: Check if results_init (or something ele?) needs to be jax numpyified
 VES_summary, VEZ_summaries, params_learned, elbo_decomposed = run_CAVI_with_JAX(
-    jnp.asarray(snip.squad_angles),
-    n_cavi_iterations,
-    results_init,
+    params_init,
+    VES_init, VEZ_init,
+    system_transition_prior,
     circle_model_JAX,
+    jnp.asarray(snip.squad_angles),
     example_end_times,
+    n_cavi_iterations,
     M_step_toggles_from_strings(
         M_step_toggle_for_STP,
         M_step_toggle_for_ETP,

--- a/tests/unit/test_hmm_posterior.py
+++ b/tests/unit/test_hmm_posterior.py
@@ -40,7 +40,7 @@ array([[[0.1 , 0.2 ],
     # hence we can fill it in with [a,1-a] for any a in [0,1].
 
     return HMM_Posterior_Summary_NUMPY(
-        expected_regimes, expected_joints, log_normalizer=None, entropy=None
+        expected_regimes, expected_joints, log_normalizer=np.nan, entropy=np.nan
     )
 
 
@@ -73,7 +73,7 @@ def posterior_summary_2():
     # hence we can fill it in with [a,1-a] for any a in [0,1].
 
     return HMM_Posterior_Summary_NUMPY(
-        expected_regimes, expected_joints, log_normalizer=None, entropy=None
+        expected_regimes, expected_joints, log_normalizer=np.nan, entropy=np.nan
     )
 
 


### PR DESCRIPTION
At a high level, the changes are:

- (bugfix) Mike h's entropy fix PR in December 2024 changed the API for `run_CAVI_with_JAX`, but didn't change caller functions.
- (bugfix) [HMM Posteriors object was being incorrectly initialized with None instead of jp.nan's. This was breaking unit tests. It is now fixed.
- (enh) Provide an additional pathway for  installing the `ssm` dependency.
- (enh) Include the SNLDS model in `demo_metrics_from_forecast_collection.py`, which produces the evaluation (metrics and plots) for the basketball experiment.  
- (enh) Update README to link to how SNLDS was trained. 

Details can be found in the commit messages.